### PR TITLE
Update DateTimePicker.js

### DIFF
--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -937,8 +937,8 @@
 					}
 					else if(dtPickerObj._compare(dtPickerObj.dataObject.sDateTimeFormat, dtPickerObj.dataObject.sArrInputDateTimeFormats[2]) || dtPickerObj._compare(dtPickerObj.dataObject.sDateTimeFormat, dtPickerObj.dataObject.sArrInputDateTimeFormats[3])) // "MM-dd-yyyy HH:mm:ss", "MM-dd-yyyy hh:mm:ss AA"
 					{
-						iMonth = parseInt(sArrDate[0]);
-						iDate = parseInt(sArrDate[1] - 1);
+						iMonth = parseInt(sArrDate[0] - 1);
+						iDate = parseInt(sArrDate[1]);
 						iYear = parseInt(sArrDate[2]);
 					}
 					else if(dtPickerObj._compare(dtPickerObj.dataObject.sDateTimeFormat, dtPickerObj.dataObject.sArrInputDateTimeFormats[4]) || dtPickerObj._compare(dtPickerObj.dataObject.sDateTimeFormat, dtPickerObj.dataObject.sArrInputDateTimeFormats[5])) // "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd hh:mm:ss AA"

--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -830,6 +830,8 @@
 					$oElem.val(sElemValue);
 				else
 					$oElem.html(sElemValue);
+					
+				$oElem.change();
 			
 				return sElemValue;
 			},


### PR DESCRIPTION
Fixed bug when parsing the following datetime format: "MM-dd-yyyy HH:mm:ss". -1 was being done to the day instead of the month.

Also:

When setting the value the change event is now raised on the element.  This allows frameworks like Knockout.js to be notified that the value changed so they can bind.
