### PR TITLE
FIxing issue when clicking for second time on input wrapped in label act...

### DIFF
--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -721,6 +721,8 @@
 				{
 					$(dtPickerObj.element).find('.dtpicker-subcontent').html("");
 				}, (iDuration || dtPickerObj.settings.animationDuration));
+
+				$(document).unbind("click");
 			},
 		
 			_modifyPicker: function()


### PR DESCRIPTION
FIxing issue when clicking for second time on input wrapped in label actually opens datetipepicker but closes it 400ms later.

```
            $(document).click(function(e)
            {
                dtPickerObj._hidePicker();
            });
            was never removed, therefore error.
```
