### PR TITLE
Add minuteIncrement capability

### DIFF
--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -48,6 +48,7 @@
 		
 			maxTime: null,
 			minTime: null,
+			minuteIncrement: 1,
 		
 			maxDateTime: null,
 			minDateTime: null,
@@ -73,7 +74,14 @@
 			
 			parentElement: null,
 		
-			addEventHandlers: null
+			addEventHandlers: null,
+			adjustMinutes: function(minutes) {
+				if (this.minuteIncrement != 1)
+				{
+					minutes = (minutes%this.minuteIncrement)?minutes-minutes%this.minuteIncrement+this.minuteIncrement:minutes;
+				}
+				return minutes;
+			}
 		};
 	
 		var dataObject = {
@@ -1067,14 +1075,14 @@
 			
 				$(dtPickerObj.element).find(".minutes .increment").click(function(e)
 				{
-					dtPickerObj.dataObject.iCurrentMinutes++;
+					dtPickerObj.dataObject.iCurrentMinutes += dtPickerObj.settings.minuteIncrement;
 					dtPickerObj._setCurrentDate();
 					dtPickerObj._setOutputOnIncrementOrDecrement();
 				});
 			
 				$(dtPickerObj.element).find(".minutes .decrement").click(function(e)
 				{
-					dtPickerObj.dataObject.iCurrentMinutes--;
+					dtPickerObj.dataObject.iCurrentMinutes -= dtPickerObj.settings.minuteIncrement;
 					dtPickerObj._setCurrentDate();
 					dtPickerObj._setOutputOnIncrementOrDecrement();
 				});
@@ -1203,6 +1211,7 @@
 						iMinutes = parseInt(sArrTimeComp[1]);
 					}
 				}
+				iMinutes = dtPickerObj.settings.adjustMinutes(iMinutes);
 			
 				dTempDate = new Date(iYear, iMonth, iDate, iHour, iMinutes, 0, 0);
 			
@@ -1275,7 +1284,8 @@
 					else if(iHour < 12 && dtPickerObj._compare(sMeridiem, "PM"))
 						iHour += 12;
 				}
-			
+				iMinutes = dtPickerObj.settings.adjustMinutes(iMinutes);
+        			
 				dTempDate = new Date(iYear, iMonth, iDate, iHour, iMinutes, 0, 0);
 			
 				return dTempDate;
@@ -1355,7 +1365,7 @@
 				if(dtPickerObj._compare(dtPickerObj.settings.mode, "time") || dtPickerObj._compare(dtPickerObj.settings.mode, "datetime"))
 				{
 					dtPickerObj.dataObject.iCurrentHour = parseInt($(dtPickerObj.element).find(".hour .dtpicker-compValue").val());
-					dtPickerObj.dataObject.iCurrentMinutes = parseInt($(dtPickerObj.element).find(".minutes .dtpicker-compValue").val());
+					dtPickerObj.dataObject.iCurrentMinutes = dtPickerObj.settings.adjustMinutes(parseInt($(dtPickerObj.element).find(".minutes .dtpicker-compValue").val()));
 				
 					if(dtPickerObj._compare(dtPickerObj.settings.mode, "time"))
 					{


### PR DESCRIPTION
I just modified the src directory.  Not running grunt locally, so you will have to do that work.  Also did not see the documentation in the repo, or I would have updated it.

Basically the minuteIncrement option allows you to increment or decrement minutes by a fixed amount.  For example, if you specify 15, then you can only choose 1:00, 1:15, 1:30, or 1:45, not 1:37.  I find I need this often for most times as I am specifying general meeting times, and want some order as to what is chosen.  Defaults to 1, which is current behavior.
