### PR TITLE
correct the 'main' field in package.json, and use 'peerDependencies' …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,7 @@
 {
-
     "name": "datetimepicker",
-
     "description": "Responsive flat design jQuery DateTime Picker plugin for Web & Mobile",
-
-    "keywords": 
+    "keywords":
     [
         "date",
         "time",
@@ -12,48 +9,33 @@
         "flat",
         "jquery"
     ],
-
     "version": "0.1.7",
-
     "homepage": "http://curioussolutions.github.io/DateTimePicker/",
-
     "author": "nehakadam",
-
-    "main": 
-    [
-        "dist/datetimepicker.js",
-        "dist/datetimepicker.css"
-    ],
-
-    "repository": 
+    "main":"dist/datetimepicker.js",
+    "repository":
     {
         "type": "git",
         "url": "git://github.com:CuriousSolutions/DateTimePicker.git"
     },
-
-    "devDependencies": 
+    "devDependencies":
     {
         "grunt": "~0.4.5",
         "grunt-contrib-cssmin": "~0.5.0",
         "grunt-contrib-uglify": "~0.4.0",
         "grunt-contrib-copy": "~0.4.0"
     },
-
-    "bugs": 
+    "bugs":
     {
         "url": "https://github.com/CuriousSolutions/DateTimePicker/issues"
     },
-
-    "dependencies": 
+    "peerDependencies":
     {
         "jquery": ">=1.0.0"
     },
-
-    "scripts": 
+    "scripts":
     {
         "test": "echo \"Error: no test specified\" && exit 1"
     },
-
     "license": "MIT"
-
 }


### PR DESCRIPTION
correct the 'main' field in 'package.json', and use 'peerDependencies' replace 'dependencies'.

The main field in the 'package.json'  should be a string , not an array. [npm doc package.json#main](https://docs.npmjs.com/files/package.json#main).

As a javascript package for browser , should use 'peerDependencies' instead of 'dependencies', then the different packages can share the dependencies . 
