### PR TITLE
eventHandlers live

### DIFF
--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -284,16 +284,16 @@
 		{
 			var dtPickerObj = this;
 		
-			dtPickerObj.dataObject.oInputElement = null;		
-			var oArrElements = undefined;
+			dtPickerObj.dataObject.oInputElement = null;
 
-
+            // -----Comment zevero: I would cut this out
 			$(dtPickerObj.settings.parentElement).find("input[type='date'], input[type='time'], input[type='datetime']").each(function()
 			{
 				var sType = $(this).attr("type");
 				$(this).attr("type", "text");
 				$(this).attr("data-field", sType);
 			});	
+            // -----until here
 			var sel = "[data-field='date'], [data-field='time'], [data-field='datetime']";
 			$(dtPickerObj.settings.parentElement).off("focus", sel, dtPickerObj._inputFieldFocus);
 			$(dtPickerObj.settings.parentElement).on ("focus", sel, {"obj": dtPickerObj}, dtPickerObj._inputFieldFocus);
@@ -301,8 +301,8 @@
 			$(dtPickerObj.settings.parentElement).off("click", sel, dtPickerObj._inputFieldClick);
 			$(dtPickerObj.settings.parentElement).on ("click", sel, {"obj": dtPickerObj}, dtPickerObj._inputFieldClick);
 
-			if(dtPickerObj.settings.addEventHandlers) //TODO is this maybe added with every call?
-				dtPickerObj.settings.addEventHandlers.call(dtPickerObj);
+			if(dtPickerObj.settings.addEventHandlers) //this is not an event-handler really. Its just a function called
+				dtPickerObj.settings.addEventHandlers.call(dtPickerObj); // which could add EventHandlers
 		},
 	
 		_inputFieldFocus: function(e)
@@ -310,7 +310,7 @@
 			var dtPickerObj = e.data.obj;
 			if(dtPickerObj.dataObject.oInputElement == null)
 			{
-				dtPickerObj.showDateTimePicker(e.target);
+				dtPickerObj.showDateTimePicker(this);
 			}
 			dtPickerObj.dataObject.bMouseDown = false;
 		},

--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -81,7 +81,7 @@
 	
 		isPopup: true,
 	
-		parentElement: null,
+		parentElement: "body",
 	
 		addEventHandlers: null,  // addEventHandlers(oDateTimePicker)
 		beforeShow: null,  // beforeShow(oInputElement)
@@ -287,46 +287,21 @@
 			dtPickerObj.dataObject.oInputElement = null;		
 			var oArrElements = undefined;
 
-			if(dtPickerObj.settings.parentElement != undefined)
-			{
-				$(dtPickerObj.settings.parentElement).find("input[type='date'], input[type='time'], input[type='datetime']").each(function()
-				{
-					var sType = $(this).attr("type");
-					$(this).attr("type", "text");
-					$(this).attr("data-field", sType);
-				});
 
-				oArrElements = $(dtPickerObj.settings.parentElement).find("[data-field='date'], [data-field='time'], [data-field='datetime']");
-			}
-			else
+			$(dtPickerObj.settings.parentElement).find("input[type='date'], input[type='time'], input[type='datetime']").each(function()
 			{
-				$("input[type='date'], input[type='time'], input[type='datetime']").each(function()
-				{
-					var sType = $(this).attr("type");
-					$(this).attr("type", "text");
-					$(this).attr("data-field", sType);
-				});
+				var sType = $(this).attr("type");
+				$(this).attr("type", "text");
+				$(this).attr("data-field", sType);
+			});	
+			var sel = "[data-field='date'], [data-field='time'], [data-field='datetime']";
+			$(dtPickerObj.settings.parentElement).off("focus", sel, dtPickerObj._inputFieldFocus);
+			$(dtPickerObj.settings.parentElement).on ("focus", sel, {"obj": dtPickerObj}, dtPickerObj._inputFieldFocus);
 			
-				oArrElements = $("[data-field='date'], [data-field='time'], [data-field='datetime']");
-			}
-		
-			$(oArrElements).unbind("focus", dtPickerObj._inputFieldFocus);
-			$(oArrElements).on("focus", {"obj": dtPickerObj}, dtPickerObj._inputFieldFocus);
-		
-			$(oArrElements).not('input').click(function(e)
-			{
-				if(dtPickerObj.dataObject.oInputElement == null)
-				{
-					dtPickerObj.showDateTimePicker(this);
-				}
-			});
-		
-			$(oArrElements).click(function(e)
-			{
-				e.stopPropagation();
-			});
-		
-			if(dtPickerObj.settings.addEventHandlers)
+			$(dtPickerObj.settings.parentElement).off("click", sel, dtPickerObj._inputFieldClick);
+			$(dtPickerObj.settings.parentElement).on ("click", sel, {"obj": dtPickerObj}, dtPickerObj._inputFieldClick);
+
+			if(dtPickerObj.settings.addEventHandlers) //TODO is this maybe added with every call?
 				dtPickerObj.settings.addEventHandlers.call(dtPickerObj);
 		},
 	
@@ -338,6 +313,15 @@
 				dtPickerObj.showDateTimePicker(e.target);
 			}
 			dtPickerObj.dataObject.bMouseDown = false;
+		},
+		_inputFieldClick: function(e)
+		{
+          	var dtPickerObj = e.data.obj;
+			if ($(this).prop("tagName")!=='input' && dtPickerObj.dataObject.oInputElement == null)
+			{
+				dtPickerObj.showDateTimePicker(this);
+			}
+			e.stopPropagation();
 		},
 
 		// Public Method


### PR DESCRIPTION
I use DateTimePicker on a dynamic page, but DateTimePicker only worked on the input fields already present and not on those, which were added later.

This version is a more live version.
And it is more efficient, because the jquery.on is not called for every field, but only once for all.
And it is using jquery.off not only on focus but also on click. So DateTimePicker can be initialized several times without harm.

I tested it for my case (without using inputs) and it works.
I did not test it with input fields. Please test.

I did not break your api and everything should be compatible to your version. But I personally would not promote every input type="date|time|datetime" to be used with DateTimePicker. I think it is clearer to enforce usage of data-field="...".
