### PR TITLE
Fixed bug when using HTML5 input types.

### DIFF
--- a/src/DateTimePicker-Zepto.js
+++ b/src/DateTimePicker-Zepto.js
@@ -522,8 +522,8 @@ var sLibrary = "zepto";
 
 			$(oDTP.settings.parentElement).find("input[type='date'], input[type='time'], input[type='datetime']").each(function()
 			{
-				$(this).attr("type", "text");
 				$(this).attr("data-field", $(this).attr("type"));
+				$(this).attr("type", "text");
 			});	
         
 			var sel = "[data-field='date'], [data-field='time'], [data-field='datetime']";

--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -520,8 +520,8 @@ $.cf = {
 
 			$(oDTP.settings.parentElement).find("input[type='date'], input[type='time'], input[type='datetime']").each(function()
 			{
-				$(this).attr("type", "text");
 				$(this).attr("data-field", $(this).attr("type"));
+				$(this).attr("type", "text");
 			});	
         
 			var sel = "[data-field='date'], [data-field='time'], [data-field='datetime']";


### PR DESCRIPTION
Since the input's type was being set to `text` first, the data field was always set to `text` and not the correct value. Reversing the order solves this.
