### PR TITLE
Stop auto hide, only hide when its focused

### DIFF
--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -1518,7 +1518,8 @@ $.cf = {
 			{
 				$(document).on("click.DateTimePicker", function(e)
 				{
-					oDTP._hidePicker("");
+					if (oDTP.oData.bElemFocused)
+						oDTP._hidePicker("");
 				});
 			}
 		


### PR DESCRIPTION
Closes issue, [#155](https://github.com/nehakadam/DateTimePicker/issues/155)
In my case my uptodate Chrome
_Version 73.0.3683.75 (Official Build) (64-bit)_
Is affected with this bug, each time dialog shows it just, auto hides, i also confirmed
that older Chrome versions, do not have this issue.